### PR TITLE
Pass the full path of the installer executable through to app on first-run

### DIFF
--- a/src/Setup/UpdateRunner.cpp
+++ b/src/Setup/UpdateRunner.cpp
@@ -259,8 +259,12 @@ gotADir:
 		lpCommandLine = L"";
 	}
 
-	wchar_t cmd[MAX_PATH];
-	swprintf_s(cmd, L"\"%s\" --install . %s", updateExePath, lpCommandLine);
+	// append the full path of this installer executable to the next stage of the process
+	wchar_t setupExePath[MAX_PATH];
+	GetModuleFileName(NULL, setupExePath, MAX_PATH);
+
+	wchar_t cmd[MAX_PATH * 2];
+	swprintf_s(cmd, L"\"%s\" --install . %s --installer-path \"%s\"", updateExePath, lpCommandLine, setupExePath);
 
 	if (!CreateProcess(NULL, cmd, NULL, NULL, false, 0, NULL, targetDir, &si, &pi)) {
 		goto failedExtract;

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -370,10 +370,20 @@ namespace Squirrel
             async Task invokePostInstall(SemanticVersion currentVersion, bool isInitialInstall, bool firstRunOnly, bool silentInstall)
             {
                 var targetDir = getDirectoryForRelease(currentVersion);
+
                 var args = isInitialInstall ?
                     String.Format("--squirrel-install {0}", currentVersion) :
                     String.Format("--squirrel-updated {0}", currentVersion);
 
+                var incomingArgs = Environment.GetCommandLineArgs();
+                var pathKeyArgIndex = Array.FindIndex(incomingArgs, arg => String.Equals(arg, "--installer-path"));
+                if (pathKeyArgIndex != -1 && incomingArgs.Length > pathKeyArgIndex + 1)
+                {
+                    var installerPath = incomingArgs[pathKeyArgIndex + 1];
+                    args += String.Format(" --squirrel-installer-path {0}", installerPath);
+                }
+                this.Log().Info("Incoming args to UpdateManager process: {0}", String.Join(",", incomingArgs));
+                this.Log().Info("Running app with args: {0}", args);
                 var squirrelApps = SquirrelAwareExecutableDetector.GetAllSquirrelAwareApps(targetDir.FullName);
 
                 this.Log().Info("Squirrel Enabled Apps: [{0}]", String.Join(",", squirrelApps));


### PR DESCRIPTION
Setup.exe (c++) modified to pass its path to Update.exe via `--installer-path XXX`.

Update.exe (c#) modified to pass its path to the installed app via `--squirrel-installer-path XXX`

Depends on #1 