### PR TITLE
Added flag to skip brave-core detection logic

### DIFF
--- a/src/Squirrel/IUpdateManager.cs
+++ b/src/Squirrel/IUpdateManager.cs
@@ -20,7 +20,11 @@ namespace Squirrel
         /// <summary>
         /// A shortcut in the application folder, useful for portable applications.
         /// </summary>
-        AppRoot = 1 << 3
+        AppRoot = 1 << 3,
+        /// <summary>
+        /// specific for adding a "Brave (old)" shortcut
+        /// </summary>
+        DuplicateDesktop = 1 << 4,
     }
 
     public interface IUpdateManager : IDisposable, IEnableLogger

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -701,6 +701,9 @@ namespace Squirrel
                 var dir = default(string);
 
                 switch (location) {
+                case ShortcutLocation.DuplicateDesktop:
+                    title += " (old)";
+                    goto case ShortcutLocation.Desktop;
                 case ShortcutLocation.Desktop:
                     dir = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
                     break;

--- a/src/StubExecutable/StubExecutable.cpp
+++ b/src/StubExecutable/StubExecutable.cpp
@@ -165,9 +165,19 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 {
 	std::wstring fullPath;
 	std::wstring workingDir;
+	bool launchLegacy = false;
+
+	// Flag to skip brave-core detection logic
+	std::wstring cmdLineArgs(lpCmdLine);
+	size_t arg_index = cmdLineArgs.find(L"--launch-muon");
+	if (arg_index != std::string::npos)
+	{
+		launchLegacy = true;
+	}
+
 	// Brave Software specific logic
 	std::wstring braveCore(FindBraveCoreInstall());
-	if (braveCore.length() > 0) {
+	if (!launchLegacy && braveCore.length() > 0) {
 		// Logic specifically for launching detected brave-core
 		workingDir.assign(braveCore);
 		fullPath = workingDir + L"\\brave.exe";


### PR DESCRIPTION
Originally suggested by @petemill in https://github.com/brave/Squirrel.Windows/pull/5#discussion_r227597695

I tried to avoid this change in favor of custom shortcut creation logic (via `brave/electron-squirrel-startup`), but it seems Squirrel is limited to linking to the stub executable ☹️ 

With this change, I can make two shortcuts in `brave/electron-squirrel-startup`; the regular shortcut... and then a second one which could be named `Brave (old)` (which includes the `--launch-muon` flag)