### PR TITLE
Don't delete the brave*.exe that's in the root (the stub executable).

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -130,7 +130,7 @@ namespace Squirrel
                     this.ErrorIfThrows(() => fixPinnedExecutables(new SemanticVersion(255, 255, 255, 255), true));
                 } catch { }
 
-                await this.ErrorIfThrows(() => Utility.DeleteDirectoryOrJustGiveUp(rootAppDirectory),
+                await this.ErrorIfThrows(() => Utility.DeleteDirectoryOrJustGiveUp(rootAppDirectory, true),
                     "Failed to delete app directory: " + rootAppDirectory);
 
                 // NB: We drop this file here so that --checkInstall will ignore 


### PR DESCRIPTION
Needs to be in place so that default browser isn't broken after
uninstall of Muon based Brave browser

Fixes https://github.com/brave/brave-browser/issues/1912